### PR TITLE
Fix for issue 14

### DIFF
--- a/src/Seq.App.YouTrack/Seq.App.YouTrack.csproj
+++ b/src/Seq.App.YouTrack/Seq.App.YouTrack.csproj
@@ -22,10 +22,10 @@
     <PackageReference Include="EmbeddedResourceLoader" Version="2.0.0" />
     <PackageReference Include="Handlebars.Net" Version="1.10.1" />
     <PackageReference Include="JsonFlatFileDataStore" Version="2.2.2" />
-    <PackageReference Include="Newtonsoft.Json" Version="12.0.3" />
-    <PackageReference Include="Seq.Apps" Version="5.1.0" />
-    <PackageReference Include="Serilog" Version="2.9.0" />
-    <PackageReference Include="YouTrackSharp" Version="2020.1.0" />
+    <PackageReference Include="Newtonsoft.Json" Version="13.0.1" />
+    <PackageReference Include="Seq.Apps" Version="2021.4.0" />
+    <PackageReference Include="Serilog" Version="2.10.0" />
+    <PackageReference Include="YouTrackSharp" Version="2021.3.6" />
   </ItemGroup>
   
   <ItemGroup>


### PR DESCRIPTION
https://github.com/ChangemakerStudios/Seq.App.YouTrack/issues/14

Upgrading the YouTrack Nuget package to the latest version will resolve the HTTP 414 status code being returned if you try and create an issue with a summary and/or description that are very long.